### PR TITLE
Make all coordinates be standard ints

### DIFF
--- a/limnos/generation.py
+++ b/limnos/generation.py
@@ -193,6 +193,9 @@ def sprout_new_random_branch(mother_trails: Trails,
 
         if len(possible_steps) > 0:
             step = possible_steps[randint(0, len(possible_steps) - 1)]
+            # now cast numpy ints to standard ints since some modules
+            # (notably json) care about the int type
+            step = (int(step[0]), int(step[1]))
             head = add_points(head, step)
             branch_route.append(head)
         else:

--- a/limnos/tests/test_generation.py
+++ b/limnos/tests/test_generation.py
@@ -4,6 +4,7 @@ Test the generation functions
 import pytest
 
 from limnos.generation import _wall_intersects_route
+from limnos.generation import trails_generator
 
 
 ROUTE = [(1, 1), (1, 3), (3, 3), (5, 3), (5, 5)]
@@ -16,3 +17,19 @@ intersects = [False, True, True]
 @pytest.mark.parametrize("wall, intersects", list(zip(walls, intersects)))
 def test_intersection_check(wall, intersects):
     assert _wall_intersects_route(ROUTE, wall) == intersects
+
+
+def test_all_route_points_contain_ints():
+    """
+    Check that all points on generated routes contain standard ints
+    """
+    N = 10
+    M = 10
+
+    trails = trails_generator(N, M)
+    routes = trails.all_routes()
+
+    for route in routes:
+        for point in route:
+            assert isinstance(point[0], int)
+            assert isinstance(point[1], int)


### PR DESCRIPTION
It's good to have types that we can believe in. Currently, some generated points have coordinates that are not `int`s but `numpy.int64`s. This somewhat subtle difference can matter e.g. when one tries to serialize to JSON.

This PR explicitly casts `numpy` `int`s to standard `int`s and adds a test to ensure the type purity.

@jeppetrost @petterbejo 