### PR TITLE
Impose canonical branch order for Trails

### DIFF
--- a/limnos/generation.py
+++ b/limnos/generation.py
@@ -296,7 +296,7 @@ def trails_generator(N: int, M: int) -> Trails:
         start = subtrail.main.index(trail_point)
         new_trail = sprout_new_random_branch(trails, subtrail, start)
         new_trail = cast(Trails, new_trail)
-        subtrail.branches.append(new_trail)
+        subtrail.add_branch(new_trail)
         all_free_points.difference_update(set(new_trail.main))
 
     return trails

--- a/limnos/tests/test_trails.py
+++ b/limnos/tests/test_trails.py
@@ -1,0 +1,52 @@
+"""
+Test module specifically for the methods of the Trails type
+"""
+
+from limnos.types import Trails
+
+
+def test_equality():
+
+    r1 = [(1, 1), (1, 3), (3, 3)]
+    t1 = Trails(r1, [])
+
+    assert t1 != r1
+
+    r1 = [(1, 1), (1, 3), (1, 5), (3, 5), (5, 5)]
+    r2 = [(1, 3), (3, 3)]
+    r3 = [(5, 5), (5, 3)]
+
+    t1 = Trails(main=r1,
+                branches=[Trails(r2, []), Trails(r3, [])])
+    t2 = Trails(main=r1,
+                branches=[Trails(r3, []), Trails(r2, [])])
+    t3 = Trails(main=r1, branches=[])
+
+    t4 = Trails(main=r1, branches=[])
+    t4.add_branch(Trails(r2, []))
+    t4.add_branch(Trails(r3, []))
+
+    assert t1 == t2
+    assert t1 != t3
+    assert t2 != t3
+    assert t1 == t2 == t4
+
+    r1 = [(1, 1), (1, 3), (3, 3), (5, 3), (7, 3), (7, 5), (7, 7)]
+    r2 = [(3, 3), (3, 5)]
+    r3 = [(3, 3), (3, 1)]
+    r4 = [(7, 5), (5, 5)]
+
+    t1 = Trails(main=r1,
+                branches=[Trails(r2, []), Trails(r3, []), Trails(r4, [])])
+    t2 = Trails(main=r1,
+                branches=[Trails(r2, []), Trails(r4, []), Trails(r3, [])])
+    t3 = Trails(main=r1,
+                branches=[Trails(r3, []), Trails(r2, []), Trails(r4, [])])
+    t4 = Trails(main=r1,
+                branches=[Trails(r3, []), Trails(r4, []), Trails(r2, [])])
+    t5 = Trails(main=r1,
+                branches=[Trails(r4, []), Trails(r2, []), Trails(r3, [])])
+    t6 = Trails(main=r1,
+                branches=[Trails(r4, []), Trails(r3, []), Trails(r2, [])])
+
+    assert t1 == t2 == t3 == t4 == t5 == t6

--- a/limnos/transforms.py
+++ b/limnos/transforms.py
@@ -9,7 +9,9 @@ from typing import Callable
 from .types import (Point,
                     Route,
                     add_points,
-                    subtract_points)
+                    subtract_points,
+                    direction_from_points,
+                    Direction)
 from .validation import (all_points_consecutive,
                          all_points_inside,
                          all_points_unique,
@@ -20,35 +22,6 @@ from .validation import (all_points_consecutive,
 class Chirality(Enum):
     LEFT = auto()
     RIGHT = auto()
-
-
-class Direction(Enum):
-    NORTH = auto()
-    SOUTH = auto()
-    EAST = auto()
-    WEST = auto()
-    NORTHEAST = auto()
-    NORTHWEST = auto()
-    SOUTHEAST = auto()
-    SOUTHWEST = auto()
-
-
-def _direction_from_points(first: Point, second: Point) -> Direction:
-    """
-    Helper to get direction from points
-    """
-    dx = second[0] - first[0]
-    dy = second[1] - first[1]
-
-    mapper = {(0, 2): Direction.NORTH,
-              (0, -2): Direction.SOUTH,
-              (2, 0): Direction.EAST,
-              (-2, 0): Direction.WEST}
-
-    if (dx, dy) not in mapper.keys():
-        raise ValueError("Invalid non-neighbour points")
-
-    return mapper[(dx, dy)]
 
 
 def _new_bender_points(starting_point: Point,
@@ -109,7 +82,7 @@ def bender(route: Route, start: int, chirality: Chirality) -> Route:
     p1 = route[start]
     p2 = route[start + 1]
 
-    direction = _direction_from_points(p1, p2)
+    direction = direction_from_points(p1, p2)
 
     new_points = _new_bender_points(p1, direction, chirality)
 

--- a/limnos/types.py
+++ b/limnos/types.py
@@ -5,6 +5,7 @@ Note that Routes contain Points of odd coordinates only, whereas
 Walls contain Points of even coordinates only
 """
 from typing import Union
+from enum import Enum, auto
 
 import numpy as np
 
@@ -16,13 +17,48 @@ Walls = list[Wall]
 Maze = tuple[Route, Walls]
 
 
+class Direction(Enum):
+    NORTH = auto()
+    SOUTH = auto()
+    EAST = auto()
+    WEST = auto()
+    NORTHEAST = auto()
+    NORTHWEST = auto()
+    SOUTHEAST = auto()
+    SOUTHWEST = auto()
+
+
+NORTH = Direction.NORTH
+SOUTH = Direction.SOUTH
+EAST = Direction.EAST
+WEST = Direction.WEST
+
+
+def direction_from_points(first: Point, second: Point) -> Direction:
+    """
+    Helper to get direction from points
+    """
+    dx = second[0] - first[0]
+    dy = second[1] - first[1]
+
+    mapper = {(0, 2): Direction.NORTH,
+              (0, -2): Direction.SOUTH,
+              (2, 0): Direction.EAST,
+              (-2, 0): Direction.WEST}
+
+    if (dx, dy) not in mapper.keys():
+        raise ValueError("Invalid non-neighbour points")
+
+    return mapper[(dx, dy)]
+
+
 class Trails():
 
     def __init__(self, main: Route, branches: list['Trails']):
 
         self.main: Route = main
         self._branches: list['Trails'] = branches
-        self._impose_canonical_branch_order()
+        self._impose_canonical_branch_order_2()
 
     @property
     def branches(self) -> list['Trails']:

--- a/limnos/types.py
+++ b/limnos/types.py
@@ -6,6 +6,7 @@ Walls contain Points of even coordinates only
 """
 from typing import Union
 
+import numpy as np
 
 Point = tuple[int, int]
 Route = list[Point]
@@ -20,7 +21,26 @@ class Trails():
     def __init__(self, main: Route, branches: list['Trails']):
 
         self.main: Route = main
-        self.branches: list['Trails'] = branches
+        self._branches: list['Trails'] = branches
+        self._impose_canonical_branch_order()
+
+    @property
+    def branches(self) -> list['Trails']:
+        return self._branches
+
+    def add_branch(self, branch: 'Trails'):
+        self._branches.append(branch)
+        self._impose_canonical_branch_order()
+
+    def _impose_canonical_branch_order(self):
+        """
+        The canonical branch order: branches are ordered by their appearance
+        as the main route is traversed from start to end
+        """
+        if len(self.branches) == 0:
+            return
+        inds = [self.main.index(branch.main[0]) for branch in self.branches]
+        self._branches = [self.branches[i] for i in np.argsort(inds)]
 
     def point_in_trails(self, point: Point) -> bool:
         """

--- a/limnos/types.py
+++ b/limnos/types.py
@@ -169,6 +169,23 @@ class Trails():
     def __repr__(self) -> str:
         return f"Trail({self.main}, {self.branches})"
 
+    def __eq__(self, other):
+
+        def _any_difference(self, other):
+            if not isinstance(other, Trails):
+                return True
+            if self.main != other.main:
+                return True
+            if len(self.branches) != len(other.branches):
+                return True
+            for b1, b2 in zip(self.branches, other.branches):
+                _any_difference(b1, b2)
+
+        if _any_difference(self, other):
+            return False
+        else:
+            return True
+
 
 def add_points(p1: Point, p2: Point) -> Point:
     """


### PR DESCRIPTION
It was suggested by @jeppetrost (in the discussion of #8) that we impose a canonical order of `Trails` branches. I really like that idea and this PR proposes one way of doing it. The idea for the canonical order is that branches are ordered by their distance - measured along the main route - from the beginning of the main route.

If this approach gets approved, I'd like to implement the `__eq__` of `Trails` in this PR too, using the canonical order. Once we have `__eq__`, adding tests for many things, including the canonical ordering itself, becomes much easier.

I'm marking this PR draft until we agree to keep/discard the ordering proposed here.

@jeppetrost @petterbejo 