### PR TITLE
Trails serialization

### DIFF
--- a/limnos/generation.py
+++ b/limnos/generation.py
@@ -193,6 +193,9 @@ def sprout_new_random_branch(mother_trails: Trails,
 
         if len(possible_steps) > 0:
             step = possible_steps[randint(0, len(possible_steps) - 1)]
+            # now cast numpy ints to standard ints since some modules
+            # (notably json) care about the int type
+            step = (int(step[0]), int(step[1]))
             head = add_points(head, step)
             branch_route.append(head)
         else:

--- a/limnos/tests/test_generation.py
+++ b/limnos/tests/test_generation.py
@@ -4,6 +4,7 @@ Test the generation functions
 import pytest
 
 from limnos.generation import _wall_intersects_route
+from limnos.generation import trails_generator
 
 
 ROUTE = [(1, 1), (1, 3), (3, 3), (5, 3), (5, 5)]
@@ -16,3 +17,19 @@ intersects = [False, True, True]
 @pytest.mark.parametrize("wall, intersects", list(zip(walls, intersects)))
 def test_intersection_check(wall, intersects):
     assert _wall_intersects_route(ROUTE, wall) == intersects
+
+
+def test_all_route_points_contain_ints():
+    """
+    Check that all points on generated routes contain standard ints
+    """
+    N = 10
+    M = 10
+
+    trails = trails_generator(N, M)
+    routes = trails.all_routes()
+
+    for route in routes:
+        for point in route:
+            assert isinstance(point[0], int)
+            assert isinstance(point[1], int)

--- a/limnos/tests/test_trails.py
+++ b/limnos/tests/test_trails.py
@@ -1,0 +1,33 @@
+"""
+Module for testing methods of the Trails object
+"""
+
+from limnos.types import Trails
+from limnos.generation import trails_generator
+
+
+def test_serialization_and_deserialization():
+    N = 10
+    M = 10
+
+    original_trails = trails_generator(N, M)
+
+    recreated_trails = Trails.deserialize(original_trails.serialize())
+
+    # Poor man's equality check, because we haven't implemented
+    # __eq__ yet for Trails
+    assert str(original_trails) == str(recreated_trails)
+
+
+def test_serialization_and_deserialization_via_strings():
+    N = 10
+    M = 10
+
+    original_trails = trails_generator(N, M)
+
+    recreated_trails = Trails.deserialize_from_string(
+        original_trails.serialize_to_string())
+
+    # Poor man's equality check, because we haven't implemented
+    # __eq__ yet for Trails
+    assert str(original_trails) == str(recreated_trails)

--- a/limnos/types.py
+++ b/limnos/types.py
@@ -21,6 +21,43 @@ TRAILS_SERIAL_VERSION = 1
 
 class Trails():
 
+    @classmethod
+    def deserialize(cls, ser: dict) -> 'Trails':
+        """
+        Deserialize a serialized Trails dictionary into a Trails object
+        """
+        assert ser['version'] == TRAILS_SERIAL_VERSION
+
+        trails = Trails(main=ser['main'], branches=[])
+
+        def _deserializer(ser: dict, trails: Trails) -> 'Trails':
+
+            for branch in ser['branches']:
+                new_trails = Trails(main=branch['main'], branches=[])
+                trails.branches.append(_deserializer(branch, new_trails))
+            return trails
+
+        return _deserializer(ser, trails)
+
+    @classmethod
+    def deserialize_from_string(cls, ser: str) -> 'Trails':
+        """
+        Deserialize a serialized Trails string into a Trails string
+        """
+
+        deser = json.loads(ser)
+        # the raw deserialization contains lists of lists of ints and not
+        # lists of tuples of ints, so we convert lists to tuples
+
+        def _lists_to_tuples(mydict):
+            mydict['main'] = [(p[0], p[1]) for p in mydict['main']]
+            for branch in mydict['branches']:
+                _lists_to_tuples(branch)
+
+        _lists_to_tuples(deser)
+
+        return cls.deserialize(deser)
+
     def __init__(self, main: Route, branches: list['Trails']):
 
         self.main: Route = main
@@ -101,7 +138,6 @@ class Trails():
 
     def __repr__(self) -> str:
         return f"Trail({self.main}, {self.branches})"
-
 
 
 def add_points(p1: Point, p2: Point) -> Point:

--- a/limnos/types.py
+++ b/limnos/types.py
@@ -5,6 +5,7 @@ Note that Routes contain Points of odd coordinates only, whereas
 Walls contain Points of even coordinates only
 """
 from typing import Union
+import json
 
 
 Point = tuple[int, int]
@@ -13,6 +14,9 @@ Routes = list[Route]
 Wall = tuple[Point, Point]
 Walls = list[Wall]
 Maze = tuple[Route, Walls]
+
+
+TRAILS_SERIAL_VERSION = 1
 
 
 class Trails():
@@ -64,6 +68,31 @@ class Trails():
 
         return trails
 
+    def serialize(self) -> dict:
+        """
+        Return a nested dict of dicts of routes containing
+        this Trails object
+        """
+        output = dict()
+
+        def _serializer(trails: Trails, output: dict) -> dict:
+            output['main'] = trails.main
+            output['branches'] = [_serializer(branch, dict())
+                                  for branch in trails.branches]
+
+            return output
+
+        output['version'] = TRAILS_SERIAL_VERSION
+        output = _serializer(self, output)
+
+        return output
+
+    def serialize_to_string(self) -> str:
+        """
+        Return a string representing this Trails object
+        """
+        return json.dumps(self.serialize())
+
     def __getitem__(self, key: list[int]) -> 'Trails':
         if len(key) == 1:
             return self.branches[key[0]]
@@ -72,6 +101,7 @@ class Trails():
 
     def __repr__(self) -> str:
         return f"Trail({self.main}, {self.branches})"
+
 
 
 def add_points(p1: Point, p2: Point) -> Point:


### PR DESCRIPTION
This draft PR is to aid the discussion in #9.

Here, a serialization and deserialization of the `Trails` object itself is implemented. Note that this PR contains the contents of #10 (but I think #10 would be good to get in irrespective of what you think of this PR), and also that testing of these methods would be a lot easier with an implementation of `__eq__`, which hinges on #11 getting a thumbs up or down. 

@jeppetrost @petterbejo 