### PR TITLE
Add mypy to CI

### DIFF
--- a/.github/workflows/basic_ci.yaml
+++ b/.github/workflows/basic_ci.yaml
@@ -1,4 +1,4 @@
-name: Run pytest
+name: Run pytest and mypy
 
 on:
     push:
@@ -42,5 +42,8 @@ jobs:
         - name: Run pytest
           run: |
             pipenv run pytest
+        - name: Run mypy
+          run: |
+            pipenv run mypy
 
 

--- a/.github/workflows/basic_ci.yaml
+++ b/.github/workflows/basic_ci.yaml
@@ -44,6 +44,6 @@ jobs:
             pipenv run pytest
         - name: Run mypy
           run: |
-            pipenv run mypy
+            pipenv run mypy limnos
 
 


### PR DESCRIPTION
Well, just that - add mypy to the basic CI. The file pytest.yaml is thus now called basic_ci.yaml. 